### PR TITLE
get rid of haproxy dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,5 @@ Build-Depends: debhelper, bash
 Package: crowdsec-haproxy-bouncer
 Provides: crowdsec-haproxy-bouncer
 Description: lua-based haproxy bouncer for Crowdsec
-Depends: haproxy (>=2.5) lua
 Architecture: all
 


### PR DESCRIPTION
get rid of haproxy dep: this is not a good idea to depend to stuff not being in main debian repository